### PR TITLE
Import HeaderValue

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use bytes::{Bytes, BytesMut};
-use http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
+use http::{
+    header::{CONTENT_DISPOSITION, CONTENT_TYPE},
+    HeaderValue
+};
 use tracing::trace;
 
 use crate::{


### PR DESCRIPTION
When using sync feature I get ```.map(HeaderValue::as_bytes)
    |             ^^^^^^^^^^^ use of undeclared type `HeaderValue` ```

This pr fix missing import 